### PR TITLE
Bugfix/player levels

### DIFF
--- a/db/migrations/20171217011931_update_enrollments_table.js
+++ b/db/migrations/20171217011931_update_enrollments_table.js
@@ -1,11 +1,11 @@
 
 exports.up = function(knex, Promise) {
   return knex.schema.table('tournament_enrollments', function (table) {
-    table.integer('level');              
+    table.integer('level');
     table.string('first_role');
-    table.integer('first_role_time_played');
+    table.float('first_role_time_played');
     table.string('second_role');
-    table.integer('second_role_time_played');
+    table.float('second_role_time_played');
     table.integer('medal_gold');
     table.integer('medal_silver');
     table.integer( 'medal_bronze');

--- a/routes/enrollments.js
+++ b/routes/enrollments.js
@@ -145,7 +145,7 @@ module.exports = (knex, owjs) => {
             'user_id': userID,
             'team_id': null,
             'tournament_id': tournamentID,
-            'level': data.profile.level,
+            'level': Number(data.profile.tier.toString() + data.profile.level.toString()),
             'role_summary': JSON.stringify(roleRanks),
             'first_role': roleRanks[0].role,
             'first_role_time_played': roleRanks[0].time,
@@ -187,7 +187,7 @@ module.exports = (knex, owjs) => {
           .where({id: currUserID})
           .then((results) => {
             if (results.length > 0 ) {
-              // Flash Message: "You've already enrolled to this tournament"
+              console.log('cant find')
               res.sendStatus(400)
             } else {
               knex
@@ -206,6 +206,8 @@ module.exports = (knex, owjs) => {
                 const isReady = (enrolledPlayers.length === teamCount * 6);
 
                 if (currBattlenetID === tournamentCreator) {
+                  console.log(tournamentCreator);
+                  console.log('creator');
                   // Flash Message: "You cannot play in a tournament you've made"
                   res.sendStatus(400);
                 } else {

--- a/routes/tournaments.js
+++ b/routes/tournaments.js
@@ -178,10 +178,10 @@ module.exports = (knex, _, env, mailGun, owjs) => {
   /**
    * Checks a string for special characters. Returns false if one is found
    * @param  {string} string string to be checked
-   * @return {boolean}        returns false if invalid characters found
+   * @return {boolean}        returns true if invalid characters found
    */
   function checkInvalidCharacters(string){
-    return !(/^[a-zA-Z0-9-#]*$/.test(string));
+    return /^[a-zA-Z0-9-#]*$/.test(string);
   }
 
   // Goes to new tournaments page
@@ -202,15 +202,14 @@ module.exports = (knex, _, env, mailGun, owjs) => {
     const twitchChannel = req.body.channel_name;
     console.log(req.body);
 
-    //
-    if(!name || !description || checkInvalidCharacters(twitchChannel) || !checkInvalidCharacters(description) || !checkInvalidCharacters(name)){
-      // STRETCH: Show 'That name has been taken' error page
+   // STRETCH: Show 'That name has been taken' error page
+    if(!name || !description || !checkInvalidCharacters(twitchChannel) || !checkInvalidCharacters(description) || !checkInvalidCharacters(name)){
       console.log(`something is wrong`)
-      console.log(!name)
-      console.log(!description)
-      console.log(!checkInvalidCharacters(twitchChannel))
-      console.log(!checkInvalidCharacters(description))
-      console.log(!checkInvalidCharacters(name))
+      console.log(name)
+      console.log(description)
+      console.log(checkInvalidCharacters(twitchChannel))
+      console.log(checkInvalidCharacters(description))
+      console.log(checkInvalidCharacters(name))
       res.sendStatus(400);
       return;
     }
@@ -274,7 +273,7 @@ module.exports = (knex, _, env, mailGun, owjs) => {
         for (let t = 0; t < teamRoster.length; t++) {
           teamRoster[t].role_summary = JSON.parse(teamRoster[t].role_summary)
         }
-        const teamSummary = _.groupBy(_.sortBy(teamRoster, "level").reverse(), 'team_id');    
+        const teamSummary = _.groupBy(_.sortBy(teamRoster, "level").reverse(), 'team_id');
         res.send(teamSummary);
 
       });

--- a/routes/users.js
+++ b/routes/users.js
@@ -8,7 +8,7 @@ module.exports = (knex, bcrypt, cookieSession, owjs) => {
   /**
    * Checks a string for special characters. Returns false if one is found
    * @param  {string} string string to be checked
-   * @return {boolean}        returns false if invalid characters found
+   * @return {boolean}        returns true if invalid characters found
    */
   function checkInvalidCharacters(string) {
     return !(/^[a-zA-Z0-9-#]*$/.test(string));
@@ -103,7 +103,8 @@ module.exports = (knex, bcrypt, cookieSession, owjs) => {
     const email = req.body.email.trim().toLowerCase();
     const password = req.body.password.trim();
     const battlenetID = req.body.battlenet.trim();
-
+    const battlenetIDLower = req.body.battlenet.trim().toLowerCase();
+    console.log(battlenetIDLower);
     //Converting bnet ID into a format that owjs can take
 
 
@@ -111,10 +112,11 @@ module.exports = (knex, bcrypt, cookieSession, owjs) => {
       return res.sendStatus(400);
     }
 
-    knex
+    knex('users')
       .select("email")
       .from("users")
-      .where({ email: email })
+      .whereRaw(`LOWER(battlenet_ID) LIKE ?`, battlenetIDLower)
+      .orWhere({email:email})
       .then((results) => {
         console.log(results);
         if (results.length === 0) {
@@ -228,6 +230,7 @@ module.exports = (knex, bcrypt, cookieSession, owjs) => {
 
               getUserIconAndbnetID(req.params.id)
                 .then((results) => {
+                  console.log(results);
                   //isUser is true if the user logged in is looking at their own profile
                   let isUser = false;
                   if(parseInt(req.session.userID) === parseInt(req.params.id)){


### PR DESCRIPTION
Now pulling levels properly into enrollments table and profile ejs page.

Level is a concat of "Tier" and "Levels" values from the results of calling overwatch-js.

Prevented uses from duplicating BNET ID's
 
First and second role time played is now a float instead of an int